### PR TITLE
Enable auto-build of conda packages.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,22 @@ language: python
 python:
   - "2.7"
   - "3.4"
-#later: - "3.3"
 # command to install dependencies
 before_install:
-  - "sudo apt-get install -qq python-numpy gcc gfortran g++ python-dev python3-dev"
+  - "sudo apt-get install -qq python-numpy gcc gfortran g++"
+  - 'if [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then sudo apt-get install python3-dev; else sudo apt-get install python-dev; fi'
 install:
   - "pip install -r requirements.txt"
   - "python -c 'import pycompilation; print(pycompilation.__version__)'"
 # command to run tests
 script: "PYTHONPATH=`pwd` py.test --pep8 --doctest-modules --ignore setup.py --ignore doc/conf.py --ignore build/"
+after_success:
+  - ./scripts/install_miniconda.sh $TRAVIS_PYTHON_VERSION $HOME/miniconda
+  - export PATH=$HOME/miniconda/bin:$PATH
+  - conda install conda-build
+  - ./scripts/travis_after_success.sh $HOME/miniconda
 notifications:
   email: false
+env:
+  global:
+    - secure: "d/HDVjCJxX4JMDlKEYBCBKZdtaXAh1HA9szseIQQcbhD/a9B0fljJgsbnJ35ljGL/aXMMoRUgVshhU3WAaLhKKl4JABPecWDKSfgePNxxAKk8PK6/91MCy7VimpVA92r1Be7NC/5RBDB9NOocud35dAbonatd6ORk+JrrE6sMoY="

--- a/scripts/install_miniconda.sh
+++ b/scripts/install_miniconda.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -e
+PY_VERSION=$1
+MINICONDA_PATH=$2
+
+if [[ "${PY_VERSION:0:1}" == "2" ]]; then
+    if [[ "${PY_VERSION}" != "2.7" ]]; then
+        echo "PY_VERSION was not set to 2.7"
+        exit 1
+    fi
+    # This saves us some downloading for this version
+    wget --quiet http://repo.continuum.io/miniconda/Miniconda-3.7.0-Linux-x86_64.sh -O miniconda.sh;
+else
+    if [[ "${PY_VERSION:0:1}" == "3.4" ]]; then
+        echo "PY_VERSION was not set to 2.7 or 3.4"
+        exit 1
+    fi
+    wget --quiet http://repo.continuum.io/miniconda/Miniconda3-3.7.0-Linux-x86_64.sh -O miniconda.sh;
+fi
+if [[ $? != 0 ]]; then
+    # Only matters when -e not used
+    echo "Failed to get Miniconda."
+    exit 1
+fi
+
+chmod +x miniconda.sh
+./miniconda.sh -b -p $MINICONDA_PATH
+export PATH="$MINICONDA_PATH/bin:$PATH"
+hash -r
+conda config --set always_yes yes --set changeps1 no
+conda update --quiet conda
+conda info -a

--- a/scripts/travis_after_success.sh
+++ b/scripts/travis_after_success.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -x # Verbose
+MINICONDA_HOME=$1
+
+GH_USER=bjodah
+GH_REPO=pybestprac
+BINSTAR_USER=$GH_USER
+if [ "$TRAVIS_REPO_SLUG" == "${GH_USER}/${GH_REPO}" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
+    # Push wheel to binstar.org (for all Python versions)
+    conda config --add channels http://conda.binstar.org/$BINSTAR_USER
+    conda install conda-build
+    conda install binstar
+    conda build conda-recipe/
+    set +x # Silent  (protect token in Travis log)
+    echo "Uploading to binstar..."
+    binstar -t ${BINSTAR_TOKEN} upload --force $MINICONDA_HOME/conda-bld/linux-64/*.tar.bz2
+fi


### PR DESCRIPTION
Make travis-ci push conda packages for Py27 and Py34 to binstar.org/bjodah when successful build on master branch.
