### PR TITLE
Fix linker flag configuration for shared libs on macs

### DIFF
--- a/pycompilation/compilation.py
+++ b/pycompilation/compilation.py
@@ -206,6 +206,12 @@ def link(obj_files, out_file=None, shared=False, CompilerRunner_=None,
     if shared:
         if '-shared' not in flags:
             flags.append('-shared')
+
+        # mimic GNU linker behavior on OS X when using -shared
+        # (otherwise likely Undefined symbol errors)
+        dl_flag = '-undefined dynamic_lookup'
+        if sys.platform == 'darwin' and dl_flag not in flags:
+            flags.append(dl_flag)
     run_linker = kwargs.pop('run_linker', True)
     if not run_linker:
         raise ValueError("link(..., run_linker=False)!?")


### PR DESCRIPTION
In general, shared object files produced here will refer to numerous python symbols (__Py*), among others. XCode's `ld` expects these to be defined at link time, it seems. But because `pyodesys.native` et al. don't (and indeed probably shouldn't) link against specific python libraries with `-lpython`, need to tell Apple's linker to calm down and look said symbols up at run time.