### PR TITLE
Support running a custom python installation

### DIFF
--- a/pycompilation/compilation.py
+++ b/pycompilation/compilation.py
@@ -269,15 +269,19 @@ def link_py_so(obj_files, so_file=None, cwd=None, libraries=None,
         # Don't use the default code below
         pass
     else:
-        from distutils import sysconfig
-        if sysconfig.get_config_var('Py_ENABLE_SHARED'):
-            ABIFLAGS = sysconfig.get_config_var('ABIFLAGS')
-            pythonlib = 'python{}.{}{}'.format(
-                sys.hexversion >> 24, (sys.hexversion >> 16) & 0xff,
-                ABIFLAGS or '')
-            libraries += [pythonlib]
+        # LIBDIR/INSTSONAME should always points to libpython (dynamic or static)
+        pylib = os.path.join(get_config_var('LIBDIR'), get_config_var('INSTSONAME'))
+        if os.path.exists(pylib):
+            libraries.append(pylib)
         else:
-            pass
+            if get_config_var('Py_ENABLE_SHARED'):
+                ABIFLAGS = get_config_var('ABIFLAGS')
+                pythonlib = 'python{}.{}{}'.format(
+                    sys.hexversion >> 24, (sys.hexversion >> 16) & 0xff,
+                    ABIFLAGS or '')
+                libraries += [pythonlib]
+            else:
+                pass
 
     flags = kwargs.pop('flags', [])
     needed_flags = ('-pthread',)

--- a/pycompilation/runners.py
+++ b/pycompilation/runners.py
@@ -287,7 +287,7 @@ class CompilerRunner(object):
         )
         if self.run_linker:
             cmd += (['-L'+x for x in self.library_dirs] +
-                    ['-l'+x for x in self.libraries] +
+                    [(x if os.path.exists(x) else '-l'+x) for x in self.libraries] +
                     self.linkline)
         counted = []
         for envvar in re.findall('\$\{(\w+)\}', ' '.join(cmd)):


### PR DESCRIPTION
When running e.g. $ PATH=/opt/python-X.Y/bin:$PATH python compiler
variables are not set (LIBRARY_PATH) to find libpython under the
custom prefix. This patch fixes this.